### PR TITLE
ST-2224: Setting version on master to 5.4.0

### DIFF
--- a/kafkacat/pom.xml
+++ b/kafkacat/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.confluent.kafkacat-images</groupId>
         <artifactId>kafkacat-images-parent</artifactId>
-        <version>5.3.1-SNAPSHOT</version>
+        <version>5.4.0-SNAPSHOT</version>
     </parent>
 
     <groupId>io.confluent.kafkacat-images</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-docker</artifactId>
-        <version>5.3.1-SNAPSHOT</version>
+        <version>5.4.0-SNAPSHOT</version>
     </parent>
 
     <groupId>io.confluent.kafkacat-images</groupId>
@@ -15,7 +15,7 @@
     <packaging>pom</packaging>
     <name>Kafkacat Docker Images</name>
     <description>Build files for Confluent's Kafkacat Docker images</description>
-    <version>5.3.1-SNAPSHOT</version>
+    <version>5.4.0-SNAPSHOT</version>
 
     <modules>
         <module>kafkacat</module>


### PR DESCRIPTION
The master branch should be using 5.4.0. At the time of the original commit I was testing against 5.3.1 because that was more stable.