### PR TITLE
ST-2560: Adding support for building debian and rhel images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,9 @@ dockerfile {
     nodeLabel = 'docker-oraclejdk8-compose-swarm'
     slackChannel = 'clients-eng'
     upstreamProjects = []
-    dockerPullDeps = []
+    dockerPullDeps = ['confluentinc/cp-base-new']
     usePackages = true
     cron = '' // Disable the cron because this job requires parameters
+    cpImages = true
+    osTypes = ['deb8', 'rhel8']
 }

--- a/kafkacat/Dockerfile.deb8
+++ b/kafkacat/Dockerfile.deb8
@@ -32,7 +32,7 @@ RUN echo "Building kafkacat ....." \
 FROM debian:stretch-slim
 
 # Make sure you use an appropriate contact address.
-MAINTAINER partner-support@confluent.io
+LABEL MAINTAINER partner-support@confluent.io
 LABEL io.confluent.docker=true
 ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID

--- a/kafkacat/Dockerfile.rhel8
+++ b/kafkacat/Dockerfile.rhel8
@@ -1,0 +1,59 @@
+#
+# Copyright 2019 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DOCKER_UPSTREAM_REGISTRY
+ARG DOCKER_UPSTREAM_TAG=rhel8-latest
+ARG PROJECT_VERSION
+ARG ARTIFACT_ID
+
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
+
+WORKDIR /build
+
+ENV VERSION=1.5.0-1
+ENV BUILD_PACKAGES="which git cmake gcc-c++ zlib-devel openldap-devel cyrus-sasl-devel openssl-devel curl-devel"
+
+RUN echo "Building kafkacat ....." \
+    && yum -q -y update \
+    && yum -q install -y $BUILD_PACKAGES \
+    && yum clean all \
+    && git clone https://github.com/edenhill/kafkacat \
+    && cd kafkacat \
+    && git checkout tags/debian/$VERSION \
+    && ./bootstrap.sh \
+    && make
+
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
+
+# Make sure you use an appropriate contact address.
+LABEL maintainer="partner-support@confluent.io"
+LABEL io.confluent.docker=true
+ARG COMMIT_ID=unknown
+LABEL io.confluent.docker.git.id=$COMMIT_ID
+ARG BUILD_NUMBER=-1
+LABEL io.confluent.docker.build.number=$BUILD_NUMBER
+
+COPY --from=0 /build/kafkacat/kafkacat /usr/local/bin/
+
+RUN echo "Installing runtime dependencies for SSL and SASL support ...." \
+    && yum -q -y update \
+        ca-certificates \
+    && echo "===> clean up ..."  \
+    && yum clean all \
+    && rm -rf /tmp/*
+
+RUN kafkacat -V
+
+CMD ["kafkacat"]


### PR DESCRIPTION
Renamed the Dockerfile to Dockerfile.deb8, and added Dockerfile.rhel8. The image now uses cp-base-new because we are building multiple versions of the new base image, one of which is the existing deb8 version which will still get used here. So to clarify, this will not upgrade the debian image to use a new version of debian even though we are using cp-base-new.

I have tested the debian image locally and it worked with cp-demo. Testing of the rhel image with cp-demo is still on going.