### PR TITLE
ST-2811: Adding support for running as appuser in rhel image

### DIFF
--- a/kafkacat/Dockerfile.rhel8
+++ b/kafkacat/Dockerfile.rhel8
@@ -25,6 +25,8 @@ WORKDIR /build
 ENV VERSION=1.5.0-1
 ENV BUILD_PACKAGES="which git make cmake gcc-c++ zlib-devel curl curl-devel openssl-devel openldap-devel cyrus-sasl-devel pkgconfig lz4-devel libzstd-devel" 
 
+USER root
+
 RUN echo "Building kafkacat ....." \
     && dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
     && yum -q -y update \
@@ -46,6 +48,8 @@ LABEL io.confluent.docker.git.id=$COMMIT_ID
 ARG BUILD_NUMBER=-1
 LABEL io.confluent.docker.build.number=$BUILD_NUMBER
 
+USER root
+
 COPY --from=0 /build/kafkacat/kafkacat /usr/local/bin/
 
 RUN echo "Installing runtime dependencies for SSL and SASL support ...." \
@@ -55,6 +59,8 @@ RUN echo "Installing runtime dependencies for SSL and SASL support ...." \
     && echo "===> clean up ..."  \
     && yum clean all \
     && rm -rf /tmp/*
+
+USER appuser
 
 RUN kafkacat -V
 


### PR DESCRIPTION
The base image now has a user account "appuser" and this change will make the service run as that user instead of root.

The PR build for this will not succeed until the new version of the base image is published with the appuser.

I tested these changes by building the image and running cp-demo.