### PR TITLE
Make kafkacat bootstrap itself in UBI8

### DIFF
--- a/kafkacat/Dockerfile.ubi8
+++ b/kafkacat/Dockerfile.ubi8
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 ARG DOCKER_UPSTREAM_REGISTRY
 ARG DOCKER_UPSTREAM_TAG=ubi8-latest
 ARG PROJECT_VERSION
@@ -28,7 +29,6 @@ ENV BUILD_PACKAGES="which git make cmake gcc-c++ zlib-devel curl curl-devel open
 USER root
 
 RUN echo "Building kafkacat ....." \
-    && microdnf install dnf \
     && dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
     && dnf -y update \
     && dnf install -y $BUILD_PACKAGES \

--- a/kafkacat/Dockerfile.ubi8
+++ b/kafkacat/Dockerfile.ubi8
@@ -13,13 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DOCKER_UPSTREAM_REGISTRY
-ARG DOCKER_UPSTREAM_TAG=ubi8-latest
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 ARG GIT_COMMIT
 
-FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
+FROM FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 WORKDIR /build
 

--- a/kafkacat/Dockerfile.ubi8
+++ b/kafkacat/Dockerfile.ubi8
@@ -33,7 +33,7 @@ RUN echo "Building kafkacat ....." \
     && dnf -y update \
     && dnf install -y $BUILD_PACKAGES \
     && dnf clean all \
-    && git clone https://github.com/edenhill/kafkacat \
+    && git clone https://github.com/andrewegel/kafkacat \
     && cd kafkacat \
     && git checkout origin/master \
     && ./bootstrap.sh \

--- a/kafkacat/Dockerfile.ubi8
+++ b/kafkacat/Dockerfile.ubi8
@@ -27,6 +27,7 @@ ENV BUILD_PACKAGES="which git make cmake gcc-c++ zlib-devel curl curl-devel open
 USER root
 
 RUN echo "Building kafkacat ....." \
+    && microdnf install dnf \
     && dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
     && dnf -y update \
     && dnf install -y $BUILD_PACKAGES \

--- a/kafkacat/Dockerfile.ubi8
+++ b/kafkacat/Dockerfile.ubi8
@@ -23,7 +23,7 @@ FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
 WORKDIR /build
 
 ENV VERSION=1.5.0-1
-ENV BUILD_PACKAGES="which git make cmake gcc-c++ zlib-devel curl curl-devel openssl-devel cyrus-sasl-devel pkgconfig lz4-devel wget tar"
+ENV BUILD_PACKAGES="which git make cmake gcc-c++ zlib-devel curl curl-devel openssl-devel cyrus-sasl-devel pkgconfig lz4-devel wget tar findutils"
 
 USER root
 

--- a/kafkacat/Dockerfile.ubi8
+++ b/kafkacat/Dockerfile.ubi8
@@ -36,7 +36,7 @@ RUN echo "Building kafkacat ....." \
     && git clone https://github.com/edenhill/kafkacat \
     && cd kafkacat \
     && git checkout origin/master \
-    && (./bootstrap.sh || cat tmp-bootstrap/librdkafka/config.log) \
+    && (./bootstrap.sh || (cat tmp-bootstrap/librdkafka/config.log; find tmp-bootstrap/librdkafka)) \
     && make \
     && ldd kafkacat
 

--- a/kafkacat/Dockerfile.ubi8
+++ b/kafkacat/Dockerfile.ubi8
@@ -24,14 +24,14 @@ FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
 WORKDIR /build
 
 ENV VERSION=1.5.0-1
-ENV BUILD_PACKAGES="which git make cmake gcc-c++ zlib-devel curl curl-devel openssl-devel openldap-devel cyrus-sasl-devel pkgconfig lz4-devel libzstd-devel" 
+ENV BUILD_PACKAGES="which git make cmake gcc-c++ zlib-devel curl curl-devel openssl-devel openldap-devel cyrus-sasl-devel pkgconfig lz4-devel wget tar"
 
 USER root
 
 RUN echo "Building kafkacat ....." \
     && dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
-    && yum -q -y update \
-    && yum -q install -y $BUILD_PACKAGES \
+    && yum -y update \
+    && yum install -y $BUILD_PACKAGES \
     && yum clean all \
     && git clone https://github.com/edenhill/kafkacat \
     && cd kafkacat \
@@ -59,7 +59,7 @@ COPY --from=0 /build/kafkacat/kafkacat /usr/local/bin/
 
 RUN echo "Installing runtime dependencies for SSL and SASL support ...." \
     && dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
-    && yum -q -y update \
+    && yum -y update \
     && yum install -y ca-certificates libzstd \
     && echo "===> clean up ..."  \
     && yum clean all \

--- a/kafkacat/Dockerfile.ubi8
+++ b/kafkacat/Dockerfile.ubi8
@@ -12,12 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+ARG DOCKER_UPSTREAM_REGISTRY
+ARG DOCKER_UPSTREAM_TAG=ubi8-latest
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 ARG GIT_COMMIT
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
 
 WORKDIR /build
 
@@ -39,7 +40,7 @@ RUN echo "Building kafkacat ....." \
     && make \
     && ldd kafkacat
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
 
 LABEL maintainer="partner-support@confluent.io"
 LABEL vendor="Confluent"

--- a/kafkacat/Dockerfile.ubi8
+++ b/kafkacat/Dockerfile.ubi8
@@ -30,9 +30,10 @@ USER root
 
 RUN echo "Building kafkacat ....." \
     && dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
-    && yum -y update \
-    && yum install -y $BUILD_PACKAGES \
-    && yum clean all \
+    && dnf -y update \
+    && dnf install -y $BUILD_PACKAGES \
+    && dnf install -y https://confluent-packaging-tools.s3-us-west-2.amazonaws.com/libzstd-devel-1.4.2-2.el8.x86_64.rpm \
+    && dnf clean all \
     && git clone https://github.com/edenhill/kafkacat \
     && cd kafkacat \
     && git checkout tags/debian/$VERSION \
@@ -59,10 +60,10 @@ COPY --from=0 /build/kafkacat/kafkacat /usr/local/bin/
 
 RUN echo "Installing runtime dependencies for SSL and SASL support ...." \
     && dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
-    && yum -y update \
-    && yum install -y ca-certificates libzstd \
+    && dnf -y update \
+    && dnf install -y ca-certificates libzstd \
     && echo "===> clean up ..."  \
-    && yum clean all \
+    && dnf clean all \
     && rm -rf /tmp/*
 
 USER appuser

--- a/kafkacat/Dockerfile.ubi8
+++ b/kafkacat/Dockerfile.ubi8
@@ -33,7 +33,7 @@ RUN echo "Building kafkacat ....." \
     && dnf -y update \
     && dnf install -y $BUILD_PACKAGES \
     && dnf clean all \
-    && git clone https://github.com/andrewegel/kafkacat \
+    && git clone https://github.com/edenhill/kafkacat \
     && cd kafkacat \
     && git checkout origin/master \
     && ./bootstrap.sh \

--- a/kafkacat/Dockerfile.ubi8
+++ b/kafkacat/Dockerfile.ubi8
@@ -58,6 +58,7 @@ USER root
 COPY --from=0 /build/kafkacat/kafkacat /usr/local/bin/
 
 RUN echo "Installing runtime dependencies for SSL and SASL support ...." \
+    && microdnf install dnf \
     && dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
     && dnf -y update \
     && dnf install -y ca-certificates \

--- a/kafkacat/Dockerfile.ubi8
+++ b/kafkacat/Dockerfile.ubi8
@@ -32,7 +32,6 @@ RUN echo "Building kafkacat ....." \
     && dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
     && dnf -y update \
     && dnf install -y $BUILD_PACKAGES \
-    && dnf install -y https://confluent-packaging-tools.s3-us-west-2.amazonaws.com/libzstd-devel-1.4.2-2.el8.x86_64.rpm \
     && dnf clean all \
     && git clone https://github.com/edenhill/kafkacat \
     && cd kafkacat \

--- a/kafkacat/Dockerfile.ubi8
+++ b/kafkacat/Dockerfile.ubi8
@@ -35,7 +35,7 @@ RUN echo "Building kafkacat ....." \
     && dnf clean all \
     && git clone https://github.com/edenhill/kafkacat \
     && cd kafkacat \
-    && git checkout tags/debian/$VERSION \
+    && git checkout origin/master \
     && ./bootstrap.sh \
     && make
 

--- a/kafkacat/Dockerfile.ubi8
+++ b/kafkacat/Dockerfile.ubi8
@@ -36,7 +36,7 @@ RUN echo "Building kafkacat ....." \
     && git clone https://github.com/edenhill/kafkacat \
     && cd kafkacat \
     && git checkout origin/master \
-    && ./bootstrap.sh \
+    && (./bootstrap.sh || cat tmp-bootstrap/librdkafka/config.log) \
     && make \
     && ldd kafkacat
 

--- a/kafkacat/Dockerfile.ubi8
+++ b/kafkacat/Dockerfile.ubi8
@@ -39,7 +39,7 @@ RUN echo "Building kafkacat ....." \
     && make \
     && ldd kafkacat
 
-FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 LABEL maintainer="partner-support@confluent.io"
 LABEL vendor="Confluent"

--- a/kafkacat/Dockerfile.ubi8
+++ b/kafkacat/Dockerfile.ubi8
@@ -17,7 +17,7 @@ ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 ARG GIT_COMMIT
 
-FROM FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 WORKDIR /build
 

--- a/kafkacat/Dockerfile.ubi8
+++ b/kafkacat/Dockerfile.ubi8
@@ -36,7 +36,7 @@ RUN echo "Building kafkacat ....." \
     && git clone https://github.com/edenhill/kafkacat \
     && cd kafkacat \
     && git checkout origin/master \
-    && (./bootstrap.sh || (cat tmp-bootstrap/librdkafka/config.log; find tmp-bootstrap/librdkafka)) \
+    && ./bootstrap.sh \
     && make \
     && ldd kafkacat
 

--- a/kafkacat/Dockerfile.ubi8
+++ b/kafkacat/Dockerfile.ubi8
@@ -24,7 +24,7 @@ FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
 WORKDIR /build
 
 ENV VERSION=1.5.0-1
-ENV BUILD_PACKAGES="which git make cmake gcc-c++ zlib-devel curl curl-devel openssl-devel openldap-devel cyrus-sasl-devel pkgconfig lz4-devel wget tar"
+ENV BUILD_PACKAGES="which git make cmake gcc-c++ zlib-devel curl curl-devel openssl-devel cyrus-sasl-devel pkgconfig lz4-devel wget tar"
 
 USER root
 
@@ -33,11 +33,12 @@ RUN echo "Building kafkacat ....." \
     && dnf -y update \
     && dnf install -y $BUILD_PACKAGES \
     && dnf clean all \
-    && git clone https://github.com/andrewegel/kafkacat \
+    && git clone https://github.com/edenhill/kafkacat \
     && cd kafkacat \
     && git checkout origin/master \
     && ./bootstrap.sh \
-    && make
+    && make \
+    && ldd kafkacat
 
 FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
 
@@ -60,7 +61,7 @@ COPY --from=0 /build/kafkacat/kafkacat /usr/local/bin/
 RUN echo "Installing runtime dependencies for SSL and SASL support ...." \
     && dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
     && dnf -y update \
-    && dnf install -y ca-certificates libzstd \
+    && dnf install -y ca-certificates \
     && echo "===> clean up ..."  \
     && dnf clean all \
     && rm -rf /tmp/*


### PR DESCRIPTION
`libzstd` was removed from EPEL8:

https://lists.fedoraproject.org/archives/list/epel-devel@lists.fedoraproject.org/message/PHEZJ7XUAGPHGJFJAAI5IGXH5PL35RZY/

And is now being included in RHEL8's repos - However, UBI8 images do not have access to the entire RHEL8 catalog, which means you can't yum install libzstd-devel unless you're building the image in a Redhat8-subscribed system. 

So we need to also need to fix `kafkacat` project to self-bootstrap its libzstd dependency.