### PR TITLE
Build kafkacat v1.5.0 for both deb and ubi

### DIFF
--- a/kafkacat/Dockerfile.deb8
+++ b/kafkacat/Dockerfile.deb8
@@ -17,17 +17,18 @@ FROM debian:stretch-slim
 
 WORKDIR /build
 
-ENV VERSION=1.3.1-1
-ENV BUILD_PACKAGES="build-essential make cmake python git curl zlib1g-dev libsasl2-dev libssl-dev"
+ENV VERSION=1.5.0
+ENV BUILD_PACKAGES="build-essential make cmake python git curl zlib1g-dev libsasl2-dev libssl-dev libcurl4-gnutls-dev pkg-config"
 
 RUN echo "Building kafkacat ....." \
     && apt-get update -y \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y $BUILD_PACKAGES \
     && git clone https://github.com/edenhill/kafkacat \
     && cd kafkacat \
-    && git checkout tags/debian/$VERSION \
-    && ./bootstrap.sh \
-    && make
+    && git checkout $VERSION \
+    && LIBRDKAFKA_VERSION=v1.4.4 ./bootstrap.sh \
+    && make \
+    && ldd kafkacat
 
 FROM debian:stretch-slim
 
@@ -51,6 +52,7 @@ RUN apt-get update -y \
         krb5-user \
         krb5-config \
         ca-certificates \
+        libcurl3-gnutls \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 CMD ["kafkacat"]

--- a/kafkacat/Dockerfile.ubi8
+++ b/kafkacat/Dockerfile.ubi8
@@ -23,7 +23,7 @@ FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
 
 WORKDIR /build
 
-ENV VERSION=1.5.0-1
+ENV VERSION=1.5.0
 ENV BUILD_PACKAGES="which git make cmake gcc-c++ zlib-devel curl curl-devel openssl-devel cyrus-sasl-devel pkgconfig lz4-devel wget tar findutils"
 
 USER root
@@ -35,7 +35,7 @@ RUN echo "Building kafkacat ....." \
     && dnf clean all \
     && git clone https://github.com/edenhill/kafkacat \
     && cd kafkacat \
-    && git checkout origin/master \
+    && git checkout $VERSION \
     && ./bootstrap.sh \
     && make \
     && ldd kafkacat


### PR DESCRIPTION
The master deb8 image is using a really old outdated kafkacat tag and an even older librdkafka.