### PR TITLE
ST-3461: Implement nano versioning

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,4 +13,5 @@ dockerfile {
     cron = '' // Disable the cron because this job requires parameters
     cpImages = true
     osTypes = ['ubi8']
+    nanoVersion = true
 }

--- a/kafkacat/pom.xml
+++ b/kafkacat/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent.kafkacat-images</groupId>
         <artifactId>kafkacat-images-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <groupId>io.confluent.kafkacat-images</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-docker</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>[6.1.0-0, 6.1.1-0)</version>
     </parent>
 
     <groupId>io.confluent.kafkacat-images</groupId>
@@ -30,7 +30,7 @@
     <packaging>pom</packaging>
     <name>Kafkacat Docker Images</name>
     <description>Build files for Confluent's Kafkacat Docker images</description>
-    <version>6.1.0-SNAPSHOT</version>
+    <version>6.1.0-0</version>
 
     <modules>
         <module>kafkacat</module>


### PR DESCRIPTION
Setting the jenkins config to use nano versioning. Removed all of the snapshot versions and replaced with nano versions. Updated all of the dependency versions.

These changes will be merged during phase two of the nano versioning roll out.