### PR TITLE
ST-4240: remove yum update in non base Docker images

### DIFF
--- a/kafkacat/Dockerfile.ubi8
+++ b/kafkacat/Dockerfile.ubi8
@@ -30,7 +30,6 @@ USER root
 
 RUN echo "Building kafkacat ....." \
     && dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
-    && dnf -y update \
     && dnf install -y $BUILD_PACKAGES \
     && dnf clean all \
     && git clone https://github.com/edenhill/kafkacat \
@@ -61,7 +60,6 @@ COPY --from=0 /build/kafkacat/kafkacat /usr/local/bin/
 RUN echo "Installing runtime dependencies for SSL and SASL support ...." \
     && microdnf install dnf \
     && dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
-    && dnf -y update \
     && dnf install -y ca-certificates \
     && echo "===> clean up ..."  \
     && dnf clean all \


### PR DESCRIPTION
non base docker scripts that run yum update will cause issues because we rely on the base image's package versions, not the packages yup update fetches