### PR TITLE
Openssl fix

### DIFF
--- a/kcat/Dockerfile.ubi8
+++ b/kcat/Dockerfile.ubi8
@@ -18,17 +18,19 @@ ARG DOCKER_UPSTREAM_TAG=ubi8-latest
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 ARG GIT_COMMIT
+ARG UBI_MINIMAL_VERSION="latest"
 
-FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
+FROM registry.access.redhat.com/ubi8/ubi-minimal:${UBI_MINIMAL_VERSION}
 
 WORKDIR /build
 
 ENV VERSION=1.7.0
-ENV BUILD_PACKAGES="which git make cmake gcc-c++ zlib-devel curl curl-devel openssl-devel cyrus-sasl-devel pkgconfig lz4-devel wget tar findutils"
+ENV BUILD_PACKAGES="which git make cmake gcc-c++ zlib-devel curl curl-devel openssl-devel cyrus-sasl-devel pkgconfig lz4-devel wget tar findutils shadow-utils"
 
 USER root
 
 RUN echo "Building kcat ....." \
+    && microdnf install dnf \ 
     && dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
     && dnf install -y $BUILD_PACKAGES \
     && dnf clean all \
@@ -39,7 +41,7 @@ RUN echo "Building kcat ....." \
     && make \
     && ldd kcat
 
-FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
+FROM registry.access.redhat.com/ubi8/ubi-minimal:${UBI_MINIMAL_VERSION}
 
 LABEL maintainer="partner-support@confluent.io"
 LABEL vendor="Confluent"
@@ -66,6 +68,7 @@ RUN ln -s /usr/local/bin/kcat /usr/local/bin/kafkacat \
     && dnf clean all \
     && rm -rf /tmp/*
 
+RUN useradd -ms /bin/bash appuser
 USER appuser
 
 RUN kcat -V

--- a/kcat/pom.xml
+++ b/kcat/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent.kafkacat-images</groupId>
         <artifactId>kafkacat-images-parent</artifactId>
-        <version>7.8.0-0</version>
+        <version>7.9.0-0</version>
     </parent>
 
     <groupId>io.confluent.kafkacat-images</groupId>

--- a/kcat/pom.xml
+++ b/kcat/pom.xml
@@ -34,4 +34,36 @@
         <docker.skip-build>false</docker.skip-build>
         <docker.skip-test>false</docker.skip-test>
     </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <configuration>
+                    <buildArgs>
+                        <UBI_MINIMAL_VERSION>${ubi.image.version}</UBI_MINIMAL_VERSION>
+                    </buildArgs>
+                </configuration>
+            </plugin>
+
+            <plugin>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <version>0.43.4</version>
+            <configuration>
+              <images>
+                <image>
+                  <build>
+                    <args>
+                      <UBI_MINIMAL_VERSION>${ubi.image.version}</UBI_MINIMAL_VERSION>
+                    </args>
+                  </build>
+                </image>
+              </images>
+            </configuration>
+          </plugin>       
+        </plugins>
+    </build>
+      
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-docker</artifactId>
-        <version>[7.8.0-0, 7.8.1-0)</version>
+        <version>[7.9.0-0, 7.9.1-0)</version>
     </parent>
 
     <groupId>io.confluent.kafkacat-images</groupId>
@@ -30,7 +30,7 @@
     <packaging>pom</packaging>
     <name>Kafkacat Docker Images</name>
     <description>Build files for Confluent's Kafkacat Docker images</description>
-    <version>7.8.0-0</version>
+    <version>7.9.0-0</version>
 
     <modules>
         <module>kcat</module>
@@ -38,6 +38,6 @@
 
     <properties>
         <component.name>kafkacat</component.name>
-        <io.confluent.kafkacat-images.version>7.8.0-0</io.confluent.kafkacat-images.version>
+        <io.confluent.kafkacat-images.version>7.9.0-0</io.confluent.kafkacat-images.version>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-docker</artifactId>
-        <version>[7.9.0-0, 7.9.1-0)</version>
+        <version>[7.8.0-0, 7.8.1-0)</version>
     </parent>
 
     <groupId>io.confluent.kafkacat-images</groupId>
@@ -30,7 +30,7 @@
     <packaging>pom</packaging>
     <name>Kafkacat Docker Images</name>
     <description>Build files for Confluent's Kafkacat Docker images</description>
-    <version>7.9.0-0</version>
+    <version>7.8.0-0</version>
 
     <modules>
         <module>kcat</module>
@@ -38,6 +38,6 @@
 
     <properties>
         <component.name>kafkacat</component.name>
-        <io.confluent.kafkacat-images.version>7.9.0-0</io.confluent.kafkacat-images.version>
+        <io.confluent.kafkacat-images.version>7.8.0-0</io.confluent.kafkacat-images.version>
     </properties>
 </project>


### PR DESCRIPTION
kafkacat images has been failing to build after openssl was made fips compliant in the cp-base-new image. This was caused due to conflicts with the openssl version needed by librdkafka. This PR removes the base image and replaces it with ubi8-minimal to prevent the conflict of openssl versions