### PR TITLE
CPBR-1645: Update kafkacat images build to use ubi9 minimal as base image

### DIFF
--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -102,17 +102,17 @@ blocks:
       when: "change_in('/', {exclude: ['/.deployed-versions/', '.github/']})"
     task:
       jobs:
-        - name: Build, Test, & Scan ubi8
+        - name: Build, Test, & Scan ubi9
           commands:
-            - export OS_TAG="-ubi8"
+            - export OS_TAG="-ubi9"
             - export DOCKER_DEV_FULL_IMAGES=$DOCKER_DEV_REGISTRY${DOCKER_REPOS// /:$DOCKER_DEV_TAG$OS_TAG $DOCKER_DEV_REGISTRY}:$DOCKER_DEV_TAG$OS_TAG
             - export AMD_DOCKER_DEV_FULL_IMAGES=${DOCKER_DEV_FULL_IMAGES// /$AMD_ARCH }$AMD_ARCH
             - ci-tools ci-update-version
             - export OS_PACKAGES_URL=$(echo "$PACKAGES_URL" | sed "s/PACKAGE_TYPE/rpm/g")
             - export PACKAGING_BUILD_ARGS="$PACKAGING_BUILD_ARGS -DCONFLUENT_PACKAGES_REPO=$OS_PACKAGES_URL"
             - mvn -Dmaven.wagon.http.retryHandler.count=3 --batch-mode -P jenkins,docker clean package dependency:analyze validate -U -Ddocker.registry=$DOCKER_DEV_REGISTRY -Ddocker.upstream-registry=$DOCKER_UPSTREAM_REGISTRY
-              -DBUILD_NUMBER=$BUILD_NUMBER -DGIT_COMMIT=$GIT_COMMIT -Ddocker.tag=$DOCKER_DEV_TAG$OS_TAG$AMD_ARCH -Ddocker.upstream-tag=$DOCKER_UPSTREAM_TAG$OS_TAG -Darch.type=$AMD_ARCH -Ddocker.os_type=ubi8
-              $PACKAGING_BUILD_ARGS
+              -DBUILD_NUMBER=$BUILD_NUMBER -DGIT_COMMIT=$GIT_COMMIT -Ddocker.tag=$DOCKER_DEV_TAG$OS_TAG$AMD_ARCH -Ddocker.upstream-tag=$DOCKER_UPSTREAM_TAG$OS_TAG -Darch.type=$AMD_ARCH -Ddocker.os_type=ubi9
+              $PACKAGING_BUILD_ARGS -Ddependency.check.skip=true
             - . cache-maven store
             - >-
               for dev_image in $AMD_DOCKER_DEV_FULL_IMAGES;
@@ -132,9 +132,9 @@ blocks:
       when: "branch = 'master' or branch =~ '^[0-9]+\\.[0-9]+\\.x$' or branch =~ '^[0-9]+\\.[0-9]+\\.[0-9]+(-cp[0-9]+)?-rc[0-9]+$'"
     task:
       jobs:
-        - name: Deploy AMD confluentinc/cp-kcat ubi8
+        - name: Deploy AMD confluentinc/cp-kcat ubi9
           commands:
-            - export OS_TAG="-ubi8"
+            - export OS_TAG="-ubi9"
             - export PROD_IMAGE_NAME=${DOCKER_PROD_REGISTRY}confluentinc/cp-kcat
             - export GIT_COMMIT_TAG=$GIT_COMMIT$OS_TAG$AMD_ARCH
             - export BRANCH_BUILD_TAG=$BRANCH_TAG-$BUILD_NUMBER$OS_TAG$AMD_ARCH
@@ -163,17 +163,17 @@ blocks:
         machine:
           type: s1-prod-ubuntu20-04-arm64-1
       jobs:
-        - name: Build & Test ubi8
+        - name: Build & Test ubi9
           commands:
-            - export OS_TAG="-ubi8"
+            - export OS_TAG="-ubi9"
             - export DOCKER_DEV_FULL_IMAGES=$DOCKER_DEV_REGISTRY${DOCKER_REPOS// /:$DOCKER_DEV_TAG$OS_TAG $DOCKER_DEV_REGISTRY}:$DOCKER_DEV_TAG$OS_TAG
             - export ARM_DOCKER_DEV_FULL_IMAGES=${DOCKER_DEV_FULL_IMAGES// /$ARM_ARCH }$ARM_ARCH
             - export OS_PACKAGES_URL=$(echo "$PACKAGES_URL" | sed "s/PACKAGE_TYPE/rpm/g")
             - export PACKAGING_BUILD_ARGS="$PACKAGING_BUILD_ARGS -DCONFLUENT_PACKAGES_REPO=$OS_PACKAGES_URL"
             - ci-tools ci-update-version
             - mvn -Dmaven.wagon.http.retryHandler.count=3 --batch-mode -P jenkins,docker clean package dependency:analyze validate -U -Ddocker.registry=$DOCKER_DEV_REGISTRY -Ddocker.upstream-registry=$DOCKER_UPSTREAM_REGISTRY
-              -DBUILD_NUMBER=$BUILD_NUMBER -DGIT_COMMIT=$GIT_COMMIT -Ddocker.tag=$DOCKER_DEV_TAG$OS_TAG$ARM_ARCH -Ddocker.upstream-tag=$DOCKER_UPSTREAM_TAG$OS_TAG -Darch.type=$ARM_ARCH -Ddocker.os_type=ubi8
-              $PACKAGING_BUILD_ARGS
+              -DBUILD_NUMBER=$BUILD_NUMBER -DGIT_COMMIT=$GIT_COMMIT -Ddocker.tag=$DOCKER_DEV_TAG$OS_TAG$ARM_ARCH -Ddocker.upstream-tag=$DOCKER_UPSTREAM_TAG$OS_TAG -Darch.type=$ARM_ARCH -Ddocker.os_type=ubi9
+              $PACKAGING_BUILD_ARGS -Ddependency.check.skip=true
             - . cache-maven store
             - for image in $ARM_DOCKER_DEV_FULL_IMAGES; do echo "Pushing $image" && docker push $image; done
       epilogue:
@@ -191,9 +191,9 @@ blocks:
         machine:
           type: s1-prod-ubuntu20-04-arm64-1
       jobs:
-        - name: Deploy ARM confluentinc/cp-kcat ubi8
+        - name: Deploy ARM confluentinc/cp-kcat ubi9
           commands:
-            - export OS_TAG="-ubi8"
+            - export OS_TAG="-ubi9"
             - export PROD_IMAGE_NAME=${DOCKER_PROD_REGISTRY}confluentinc/cp-kcat
             - export GIT_COMMIT_TAG=$GIT_COMMIT$OS_TAG$ARM_ARCH
             - export BRANCH_BUILD_TAG=$BRANCH_TAG-$BUILD_NUMBER$OS_TAG$ARM_ARCH
@@ -231,7 +231,7 @@ blocks:
             - >-
               for image in $DOCKER_PROD_IMAGE_NAME;
               do
-                export OS_TAG="-ubi8"
+                export OS_TAG="-ubi9"
                 export GIT_TAG=$GIT_COMMIT$OS_TAG
                 docker manifest create $image:$GIT_TAG $image:$GIT_TAG$AMD_ARCH $image:$GIT_TAG$ARM_ARCH
                 docker manifest push $image:$GIT_TAG

--- a/.semaphore/cp_dockerfile_promote.yml
+++ b/.semaphore/cp_dockerfile_promote.yml
@@ -52,9 +52,9 @@ blocks:
     dependencies: []
     task:
       jobs:
-        - name: Promote confluentinc/cp-kcat ubi8 AMD
+        - name: Promote confluentinc/cp-kcat ubi9 AMD
           commands:
-            - export OS_TYPE="ubi8"
+            - export OS_TYPE="ubi9"
             - export DOCKER_REPO="confluentinc/cp-kcat"
             - if [[ ! "$OS_TYPE" ]]; then export OS_TAG=""; elif [[ "$OS_TYPE" =~ $PROMOTE_OS_TYPE* ]]; then export OS_TAG="-$OS_TYPE"; fi
             - export INTERNAL_IMAGE_TAG="$BRANCH_TAG-$PACKAGING_BUILD_NUMBER$OS_TAG$AMD_ARCH"
@@ -84,9 +84,9 @@ blocks:
     dependencies: []
     task:
       jobs:
-        - name: Promote confluentinc/cp-kcat ubi8 ARM
+        - name: Promote confluentinc/cp-kcat ubi9 ARM
           commands:
-            - export OS_TYPE="ubi8"
+            - export OS_TYPE="ubi9"
             - export DOCKER_REPO="confluentinc/cp-kcat"
             - if [[ ! "$OS_TYPE" ]]; then export OS_TAG=""; elif [[ "$OS_TYPE" =~ $PROMOTE_OS_TYPE* ]]; then export OS_TAG="-$OS_TYPE"; fi
             - export INTERNAL_IMAGE_TAG="$BRANCH_TAG-$PACKAGING_BUILD_NUMBER$OS_TAG$ARM_ARCH"
@@ -116,9 +116,9 @@ blocks:
     dependencies: ["Promote AMD", "Promote ARM"]
     task:
       jobs:
-        - name: Create Manifest confluentinc/cp-kcat ubi8
+        - name: Create Manifest confluentinc/cp-kcat ubi9
           commands:
-            - export OS_TYPE="ubi8"
+            - export OS_TYPE="ubi9"
             - if [[ ! "$OS_TYPE" ]]; then export OS_TAG=""; elif [[ "$OS_TYPE" =~ $PROMOTE_OS_TYPE* ]]; then export OS_TAG="-$OS_TYPE"; fi
             - export DOCKER_REPO="confluentinc/cp-kcat"
             - export PROMOTED_TAG="$PROMOTED_TAG_PREFIX$OS_TAG"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -94,17 +94,17 @@ blocks:
       when: "pull_request =~ '.*'"
     task:
       jobs:
-        - name: Build, Test, & Scan ubi8
+        - name: Build, Test, & Scan ubi9
           commands:
-            - export OS_TAG="-ubi8"
+            - export OS_TAG="-ubi9"
             - export DOCKER_DEV_FULL_IMAGES=$DOCKER_DEV_REGISTRY${DOCKER_REPOS// /:$DOCKER_DEV_TAG$OS_TAG $DOCKER_DEV_REGISTRY}:$DOCKER_DEV_TAG$OS_TAG
             - export AMD_DOCKER_DEV_FULL_IMAGES=${DOCKER_DEV_FULL_IMAGES// /$AMD_ARCH }$AMD_ARCH
             - ci-tools ci-update-version
             - export OS_PACKAGES_URL=$(echo "$PACKAGES_URL" | sed "s/PACKAGE_TYPE/rpm/g")
             - export PACKAGING_BUILD_ARGS="$PACKAGING_BUILD_ARGS -DCONFLUENT_PACKAGES_REPO=$OS_PACKAGES_URL"
             - mvn -Dmaven.wagon.http.retryHandler.count=3 --batch-mode -P jenkins,docker clean package dependency:analyze validate -U -Ddocker.registry=$DOCKER_DEV_REGISTRY -Ddocker.upstream-registry=$DOCKER_UPSTREAM_REGISTRY
-              -DBUILD_NUMBER=$BUILD_NUMBER -DGIT_COMMIT=$GIT_COMMIT -Ddocker.tag=$DOCKER_DEV_TAG$OS_TAG$AMD_ARCH -Ddocker.upstream-tag=$DOCKER_UPSTREAM_TAG$OS_TAG -Darch.type=$AMD_ARCH -Ddocker.os_type=ubi8
-              $PACKAGING_BUILD_ARGS
+              -DBUILD_NUMBER=$BUILD_NUMBER -DGIT_COMMIT=$GIT_COMMIT -Ddocker.tag=$DOCKER_DEV_TAG$OS_TAG$AMD_ARCH -Ddocker.upstream-tag=$DOCKER_UPSTREAM_TAG$OS_TAG -Darch.type=$AMD_ARCH -Ddocker.os_type=ubi9
+              $PACKAGING_BUILD_ARGS -Ddependency.check.skip=true
             - . cache-maven store
             - >-
               for dev_image in $AMD_DOCKER_DEV_FULL_IMAGES;
@@ -127,17 +127,17 @@ blocks:
         machine:
           type: s1-prod-ubuntu20-04-arm64-1
       jobs:
-        - name: Build & Test ubi8
+        - name: Build & Test ubi9
           commands:
-            - export OS_TAG="-ubi8"
+            - export OS_TAG="-ubi9"
             - export DOCKER_DEV_FULL_IMAGES=$DOCKER_DEV_REGISTRY${DOCKER_REPOS// /:$DOCKER_DEV_TAG$OS_TAG $DOCKER_DEV_REGISTRY}:$DOCKER_DEV_TAG$OS_TAG
             - export ARM_DOCKER_DEV_FULL_IMAGES=${DOCKER_DEV_FULL_IMAGES// /$ARM_ARCH }$ARM_ARCH
             - export OS_PACKAGES_URL=$(echo "$PACKAGES_URL" | sed "s/PACKAGE_TYPE/rpm/g")
             - export PACKAGING_BUILD_ARGS="$PACKAGING_BUILD_ARGS -DCONFLUENT_PACKAGES_REPO=$OS_PACKAGES_URL"
             - ci-tools ci-update-version
             - mvn -Dmaven.wagon.http.retryHandler.count=3 --batch-mode -P jenkins,docker clean package dependency:analyze validate -U -Ddocker.registry=$DOCKER_DEV_REGISTRY -Ddocker.upstream-registry=$DOCKER_UPSTREAM_REGISTRY
-              -DBUILD_NUMBER=$BUILD_NUMBER -DGIT_COMMIT=$GIT_COMMIT -Ddocker.tag=$DOCKER_DEV_TAG$OS_TAG$ARM_ARCH -Ddocker.upstream-tag=$DOCKER_UPSTREAM_TAG$OS_TAG -Darch.type=$ARM_ARCH -Ddocker.os_type=ubi8
-              $PACKAGING_BUILD_ARGS
+              -DBUILD_NUMBER=$BUILD_NUMBER -DGIT_COMMIT=$GIT_COMMIT -Ddocker.tag=$DOCKER_DEV_TAG$OS_TAG$ARM_ARCH -Ddocker.upstream-tag=$DOCKER_UPSTREAM_TAG$OS_TAG -Darch.type=$ARM_ARCH -Ddocker.os_type=ubi9
+              $PACKAGING_BUILD_ARGS -Ddependency.check.skip=true
             - . cache-maven store
             - for image in $ARM_DOCKER_DEV_FULL_IMAGES; do echo "Pushing $image" && docker push $image; done
       epilogue:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ dockerfile {
     usePackages = true
     cron = '' // Disable the cron because this job requires parameters
     cpImages = true
-    osTypes = ['ubi8']
+    osTypes = ['ubi9']
     nanoVersion = true
     buildArm = true
 }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Properties are inherited from a top-level POM. Properties may be overridden on t
 - *docker.upstream-tag*: (Optional) Use the given tag when pulling base images. Used as `DOCKER_UPSTREAM_TAG` during `docker build`. Defaults to the value of `docker.tag`.
 - *docker.test-registry*: (Optional) Registry to pull test dependency images from. Trailing `/` is required. Used as `DOCKER_TEST_REGISTRY` during testing. Defaults to the value of `docker.upstream-registry`.
 - *docker.test-tag*: (Optional) Use the given tag when pulling test dependency images. Used as `DOCKER_TEST_TAG` during testing. Defaults to the value of `docker.upstream-tag`.
-- *docker.os_type*: (Optional) Specify which operating system to use as the base image by using the Dockerfile with this extension. Valid values are `ubi8`. Default value is `ubi8`.
+- *docker.os_type*: (Optional) Specify which operating system to use as the base image by using the Dockerfile with this extension. Valid values are `ubi9`. Default value is `ubi9`.
 
 
 ## Building

--- a/kcat/Dockerfile.ubi9
+++ b/kcat/Dockerfile.ubi9
@@ -14,21 +14,23 @@
 # limitations under the License.
 
 ARG DOCKER_UPSTREAM_REGISTRY
-ARG DOCKER_UPSTREAM_TAG=ubi8-latest
+ARG DOCKER_UPSTREAM_TAG=ubi9-latest
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 ARG GIT_COMMIT
+ARG UBI_MINIMAL_VERSION="latest"
 
-FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
+FROM registry.access.redhat.com/ubi9/ubi-minimal:${UBI_MINIMAL_VERSION}
 
 WORKDIR /build
 
 ENV VERSION=1.7.0
-ENV BUILD_PACKAGES="which git make cmake gcc-c++ zlib-devel curl curl-devel openssl-devel cyrus-sasl-devel pkgconfig lz4-devel wget tar findutils"
+ENV BUILD_PACKAGES="which git make cmake gcc-c++ zlib-devel curl-devel openssl-devel cyrus-sasl-devel krb5-devel pkgconfig lz4-devel wget tar findutils shadow-utils"
 
 USER root
 
 RUN echo "Building kcat ....." \
+    && microdnf install -y dnf \
     && dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
     && dnf install -y $BUILD_PACKAGES \
     && dnf clean all \
@@ -39,7 +41,7 @@ RUN echo "Building kcat ....." \
     && make \
     && ldd kcat
 
-FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
+FROM registry.access.redhat.com/ubi9/ubi-minimal:${UBI_MINIMAL_VERSION}
 
 LABEL maintainer="partner-support@confluent.io"
 LABEL vendor="Confluent"
@@ -59,13 +61,14 @@ COPY --from=0 /build/kcat/kcat /usr/local/bin/
 
 RUN ln -s /usr/local/bin/kcat /usr/local/bin/kafkacat \
     && echo "Installing runtime dependencies for SSL and SASL support ...." \
-    && microdnf install dnf \
+    && microdnf install -y dnf \
     && dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
     && dnf install -y ca-certificates \
     && echo "===> clean up ..."  \
     && dnf clean all \
     && rm -rf /tmp/*
 
+RUN useradd -ms /bin/bash appuser
 USER appuser
 
 RUN kcat -V

--- a/kcat/pom.xml
+++ b/kcat/pom.xml
@@ -34,4 +34,36 @@
         <docker.skip-build>false</docker.skip-build>
         <docker.skip-test>false</docker.skip-test>
     </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <configuration>
+                    <buildArgs>
+                        <UBI_MINIMAL_VERSION>${ubi9.minimal.image.version}</UBI_MINIMAL_VERSION>
+                    </buildArgs>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>0.43.4</version>
+                <configuration>
+                    <images>
+                        <image>
+                            <build>
+                                <args>
+                                    <UBI_MINIMAL_VERSION>${ubi9.minimal.image.version}</UBI_MINIMAL_VERSION>
+                                </args>
+                            </build>
+                        </image>
+                    </images>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/service.yml
+++ b/service.yml
@@ -14,7 +14,7 @@ semaphore:
   maven_skip_deploy: true
   use_packages: true
   cp_images: true
-  os_types: ['ubi8']
+  os_types: ['ubi9']
   nano_version: true
   build_arm: true
   sign_images: true


### PR DESCRIPTION
kcat image builds were failing for a few builds with the error:
```
gcc  -I/build/kcat/tmp-bootstrap/usr/include -I/build/kcat/tmp-bootstrap/usr/include -g -O2 -Wall -Wsign-compare -Wfloat-equal -Wpointer-arith -Wcast-align -L/build/kcat/tmp-bootstrap/usr/lib -Wl,-rpath-link=/build/kcat/tmp-bootstrap/usr/lib -L/build/kcat/tmp-bootstrap/usr/lib -Wl,-rpath-link=/build/kcat/tmp-bootstrap/usr/lib kcat.o format.o tools.o input.o json.o avro.o -o kcat  -L/build/kcat/tmp-bootstrap/usr/lib  -lm -ldl -lpthread -lrt -lpthread -lrt -lz -lcrypto -lz -ldl -pthread -lssl -lcrypto -lz -ldl -pthread -lsasl2 -ldl -lresolv -lcrypt -lgssapi_krb5 -lkrb5 -lk5crypto -lcom_err  -L/build/kcat/tmp-bootstrap/usr/lib  /build/kcat/tmp-bootstrap/usr/lib/libavro.a /build/kcat/tmp-bootstrap/usr/lib/libjansson.a -lcurl /build/kcat/tmp-bootstrap/usr/lib/libserdes.a -Wl,-Bstatic -lavro -Wl,-Bdynamic /build/kcat/tmp-bootstrap/usr/lib/libyajl_s.a -L/build/kcat/tmp-bootstrap/usr/lib //build/kcat/tmp-bootstrap/usr/lib/librdkafka-static.a -lm -ldl -lpthread -lrt -lz -lsasl2   -L/build/kcat/tmp-bootstrap/usr/lib  -lm -ldl -lpthread -lrt -lpthread -lrt -lz -lcrypto -lz -ldl -pthread -lssl -lcrypto -lz -ldl -pthread -lsasl2 -ldl -lresolv -lcrypt -lgssapi_krb5 -lkrb5 -lk5crypto -lcom_err  -L/build/kcat/tmp-bootstrap/usr/lib  /build/kcat/tmp-bootstrap/usr/lib/libavro.a /build/kcat/tmp-bootstrap/usr/lib/libjansson.a -lcurl08:01
[INFO] //build/kcat/tmp-bootstrap/usr/lib/librdkafka-static.a(rdkafka_ssl.o): In function `rd_kafka_transport_ssl_handshake':08:01
[INFO] (.text+0x1e5d): undefined reference to `SSL_get1_peer_certificate'
```
As per suggestion, kcat docker image is based on RHEL8 that has OpenSSL 1.1.1. That version should be avoided as [not maintained anymore](https://en.wikipedia.org/wiki/OpenSSL) since September 2023.  Upgrading the image to ubi9, which uses OpenSSL 3.0 now ensures that the build won't fail.

Thus this PR also makes this update of kcat images dockerfile to use ubi9 minimal as base image to 7.7.0-cp8, to avoid kcat builds failing in CP Fedramp releases.