### PR TITLE
CPBR-3643: Update kcat version from 1.7.0 to 1.7.1 to address deprecated librdkafka

### DIFF
--- a/kcat/Dockerfile.ubi8
+++ b/kcat/Dockerfile.ubi8
@@ -23,7 +23,7 @@ FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
 
 WORKDIR /build
 
-ENV VERSION=1.7.0
+ENV VERSION=1.7.1
 ENV BUILD_PACKAGES="which git make cmake gcc-c++ zlib-devel curl curl-devel openssl-devel cyrus-sasl-devel pkgconfig lz4-devel wget tar findutils"
 
 USER root


### PR DESCRIPTION
## Summary

Update `edenhill/kcat` version from **1.7.0** to **1.7.1** in the UBI8 Dockerfile to resolve deprecated librdkafka dependency issue.

## Problem

The deprecated **librdkafka 1.7.0** version is currently being shipped in Confluent images via the kafkacat-images repository. Investigation traced the source to:
- `kafkacat-images` uses `edenhill/kcat:1.7.0`
- The `edenhill/kcat:1.7.0` tag is built with deprecated **librdkafka 1.7.0**

## Solution

Update to `edenhill/kcat:1.7.1`, which is built with **librdkafka 1.8.2**. 
## Changes

**File modified:** `kcat/Dockerfile.ubi8`
```diff
-ENV VERSION=1.7.0
+ENV VERSION=1.7.1
```

