### PR TITLE
CPBR-3643: Update kcat version from 1.7.0 to 1.7.1 (cherry-pick from 7.4.x)

### DIFF
--- a/kcat/Dockerfile.ubi8
+++ b/kcat/Dockerfile.ubi8
@@ -24,7 +24,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:${UBI_MINIMAL_VERSION}
 
 WORKDIR /build
 
-ENV VERSION=1.7.0
+ENV VERSION=1.7.1
 ENV BUILD_PACKAGES="which git make cmake gcc-c++ zlib-devel curl curl-devel openssl-devel cyrus-sasl-devel pkgconfig lz4-devel wget tar findutils shadow-utils"
 
 USER root


### PR DESCRIPTION
## Summary
- Cherry-pick of PR #121 (commit 246cd10) from 7.4.x to 7.8.x
- Updates kcat version from 1.7.0 to 1.7.1 to address deprecated librdkafka (INC-9515)
- The automatic pint merge from 7.7.x to 7.8.x got a conflict and was resolved using strategy ours, so this fix was never propagated to 7.8.x+. Creating this PR to manually cherry-pick the change.
