### PR TITLE
CPBR-3643: Update kcat version from 1.7.0 to 1.7.1 (cherry-pick from 7.4.x)

### DIFF
--- a/kcat/Dockerfile.ubi9
+++ b/kcat/Dockerfile.ubi9
@@ -24,7 +24,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:${UBI_MINIMAL_VERSION}
 
 WORKDIR /build
 
-ENV VERSION=1.7.0
+ENV VERSION=1.7.1
 ENV BUILD_PACKAGES="which git make cmake gcc-c++ zlib-devel curl-devel openssl-devel cyrus-sasl-devel krb5-devel pkgconfig lz4-devel wget tar findutils shadow-utils"
 
 USER root


### PR DESCRIPTION
## Summary
- Update kcat version from 1.7.0 to 1.7.1 to address deprecated librdkafka (INC-9515)
- Cherry-pick of PR #121 adapted for Dockerfile.ubi9 on 8.0.x+
- PR #129 covers 7.8.x (Dockerfile.ubi8). This PR covers 8.0.x (Dockerfile.ubi9)
- After merge, pint merge forward to 8.1.x → 8.2.x → master
